### PR TITLE
Add DisableInlineCopyButton setting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,10 +17,19 @@ const settings = [
     default: "0em"
   },
   {
+    key: "DisableInlineCopyButton",
+    title: "Don't show inline copy code cutton",
+    description:
+      "Check this box if you don't want copy code button next to inline code.",
+    default: false,
+    type: "boolean",
+    enumPicker: "checkbox",
+  },
+  {
     key: "AlwaysShowInlineCopyButton",
     title: "Always show inline copy code button?",
-    description: "Check the box if you would like the copy code button to always show next to inline code. If unchecked, the copy code button will only appear when hovering over the inline code.",
-    default: false,
+    defaul      "Check the box if you would like the copy code button to always show next to inline code. If unchecked, the copy code button will only appear when hovering over the inline code. Note: This option is obsolete when DisableInlineCopyButton is checked.",
+t: false,
     type: "boolean",
     enumPicker: "checkbox"
   }
@@ -61,10 +70,15 @@ const main = async () => {
           for (const code of code_mirror) {
             insertCopyCodeButton_CodeBlock();
           }
-          // after exiting edit mode, insert the copy copy button next to inline code
-          const inline_code_text = added_node.querySelectorAll(".content :not(pre) > code");
-          for (const text of inline_code_text) {
-            insertCopyCodeButton_InlineCode();
+
+          if (!logseq.settings.DisableInlineCopyButton) {
+            // after exiting edit mode, insert the copy copy button next to inline code
+            const inline_code_text = added_node.querySelectorAll(
+              ".content :not(pre) > code",
+            );
+            for (const text of inline_code_text) {
+              insertCopyCodeButton_InlineCode();
+            }
           }
         }
       }


### PR DESCRIPTION
I find the Inline copy button annoying. I only every want to copy stuff from multi line codeblocks. It would be nice to have a setting that disables inline copy button.

I am unable to test this out. I would require some additional help to test out the changes. Let me know if you can help me with that @vyleung 